### PR TITLE
Don't call aref on undefined variable

### DIFF
--- a/farmhouse-theme-common.el
+++ b/farmhouse-theme-common.el
@@ -286,7 +286,8 @@
       ',name
       `(ansi-color-names-vector
         [,base6 ,red2 ,green2 ,yellow2 ,blue2 ,purple2 ,cyan2 ,base1])
-      `(when (not (facep (aref ansi-term-color-vector 0)))
+      `(when (or (not (boundp 'ansi-term-color-vector))
+                 (not (facep (aref ansi-term-color-vector 0))))
          (ansi-term-color-vector
           [unspecified ,base6 ,red2 ,green2 ,yellow2 ,blue2 ,purple2 ,base1]))
       )))


### PR DESCRIPTION
Calling `(aref ansi-term-color-vector 0)` when `ansi-term-color-vector`
isn't already defined results an exception, so check to make sure it
exists before investigating it.

I defaulted to setting the variable if it doesn't already exist so it's
loaded if someone calls ansi-term later, presuming that they'll
overwrite this variable if they don't want to use farmhouse theme for it.
